### PR TITLE
Specify group using binary search

### DIFF
--- a/loadBalancer/src/main/scala/com/github/mattszm/panda/loadbalancer/RandomLoadBalancerImpl.scala
+++ b/loadBalancer/src/main/scala/com/github/mattszm/panda/loadbalancer/RandomLoadBalancerImpl.scala
@@ -9,6 +9,11 @@ import org.slf4j.LoggerFactory
 
 import scala.util.Random
 
+/**
+ * This is an important feature in the worst-case scenario. However, because of that, the solution is relatively slow.
+ * The RandomLoadBalancer should be used only with a small number of participants. In other cases, either
+ * the RoundRobinLoadBalancer or HashLoadBalancer should be preferred.
+ */
 final class RandomLoadBalancerImpl(private val client: Client[Task],
                                    private val participantsCache: ParticipantsCache) extends LoadBalancer {
   private val logger = LoggerFactory.getLogger(getClass.getName)

--- a/routes/src/main/scala/com/github/mattszm/panda/routes/RoutesTree.scala
+++ b/routes/src/main/scala/com/github/mattszm/panda/routes/RoutesTree.scala
@@ -15,9 +15,10 @@ object RoutesTree {
   final case class Fixed(expression: String) extends Value
   final case object Wildcard extends Value
 
-  final case class Node(value: Value, children: List[Node], groupInfo: Option[GroupInfo] = Option.empty)
+  final case class Node(value: Value, children: Vector[Node], groupInfo: Option[GroupInfo] = Option.empty)
   implicit val orderingByValueType: Ordering[Node] = Ordering.by { _.value match {
-    case _: Fixed => 0
-    case Wildcard => 1
+      // Wildcard will be always at the end, whereas Fixed are sorted by expression.
+    case Fixed(expression) => (0, expression)
+    case Wildcard => (1, "")
   }}
 }

--- a/routes/src/main/scala/com/github/mattszm/panda/routes/RoutesTreeImpl.scala
+++ b/routes/src/main/scala/com/github/mattszm/panda/routes/RoutesTreeImpl.scala
@@ -1,6 +1,6 @@
 package com.github.mattszm.panda.routes
 
-import RoutesTree.{Fixed, Node, Wildcard}
+import com.github.mattszm.panda.routes.RoutesTree.{Fixed, Node, Wildcard}
 import com.github.mattszm.panda.routes.dto.RoutesMappingInitDto
 import org.http4s.Uri
 import org.http4s.Uri.Path
@@ -12,15 +12,43 @@ final class RoutesTreeImpl(private val root: Node) extends RoutesTree {
   override def specifyGroup(path: Path): Option[GroupInfo] = {
     def rc(curr: Node, segments: List[Uri.Path.Segment]): Option[GroupInfo] = {
       if (segments.isEmpty) curr.groupInfo
-      else curr.children.find(node => node.value match {
-        case Fixed(expression) if expression == segments.head.encoded => true
-        case _: Fixed => false
-        case Wildcard => true
-      }).flatMap(rc(_, segments.tail))
+      else {
+        val (fixed, wildcard): (Vector[Node], Option[Node]) = curr.children.lastOption match {
+          case None => (Vector.empty, Option.empty)
+          case Some(node) if node.value == Wildcard => (curr.children.tail, Some(node))
+          case Some(_) => (curr.children, Option.empty)
+        }
+
+        fixed.binarySearch(segments.head.encoded).orElse(wildcard).flatMap(rc(_, segments.tail))
+      }
     }
 
     rc(root, path.segments.toList)
   }
+
+  implicit class NodeVectorOps(nodes: Vector[Node]) {
+    @scala.annotation.tailrec
+    private def bs(nodes: Vector[Node], left: Int, right: Int, expr: String): Option[Node] = {
+      if (right < left) Option.empty
+      else {
+        val middle = (left + right) / 2
+        val midElement = nodes(middle)
+        val midValue = midElement.value match {
+          case Fixed(expression) => expression
+          case Wildcard => "" // the wildcard should never be here
+        }
+
+        if (midValue == expr) Some(midElement)
+        else {
+          if (expr.compareTo(midValue) > 0) bs(nodes, middle + 1, right, expr)
+          else bs(nodes, left, middle - 1, expr)
+        }
+      }
+    }
+
+    def binarySearch(expr: String): Option[Node] = bs(nodes, 0, nodes.length - 1, expr)
+  }
+
 }
 
 object RoutesTreeImpl {
@@ -31,7 +59,7 @@ object RoutesTreeImpl {
   def construct(data: RoutesMappingInitDto, httpMethod: HttpMethod = HttpMethod.Get): RoutesTree =
     new RoutesTreeImpl(
       data.get(httpMethod).iterator
-        .foldLeft(Node(RoutesTree.Wildcard, List.empty))((root, entry) =>
+        .foldLeft(Node(RoutesTree.Wildcard, Vector.empty))((root, entry) =>
           insert(
             root = root,
             path = entry._1,
@@ -48,9 +76,10 @@ object RoutesTreeImpl {
     def rc(parts: List[RoutesTree.Value], currentNode: Node): Node = {
       if (parts.isEmpty) currentNode.copy(groupInfo = Some(info))
       else {
-        val affectedNode = currentNode.children.find(_.value == parts.head).getOrElse(Node(parts.head, List.empty))
+        val affectedNode = currentNode.children.find(_.value == parts.head).getOrElse(Node(parts.head, Vector.empty))
         currentNode.copy(
-          children = (rc(parts.tail, affectedNode) :: currentNode.children.filterNot(_.value == parts.head)).sorted
+          children = (rc(parts.tail, affectedNode) +: currentNode.children.filterNot(_.value == parts.head))
+            .sorted(RoutesTree.orderingByValueType)
         )
       }
     }


### PR DESCRIPTION
The solution improves performance in the case of a huge number of routes. 
However, this is worth analyzing if it's actually needed. The solution complexity is much higher and the `Vector`  itself is slow... which may cause a decrease in performance in most cases (hundreds/thousands of routes instead of hundred of thousands)